### PR TITLE
Close discord when installing

### DIFF
--- a/NodeInstaller/install.bat
+++ b/NodeInstaller/install.bat
@@ -5,6 +5,7 @@ if %errorlevel%==1 (
     start "" "https://nodejs.org/dist/latest/win-x86/node.exe"
     pause
 ) else (
-	cmd /k node.exe index.js
+    taskkill /f /im "Discord.exe" >nul 2>nul
+    cmd /k node.exe index.js
 )
 exit


### PR DESCRIPTION
Simple edit to the bat to close Discord before installing so the errors won't pop up.