### PR TITLE
Fix for random doubling of public server button

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -165,7 +165,7 @@ Core.prototype.init = function() {
         console.log(new Date().getTime() + " Defer");
         if($(".guilds-wrapper .guilds").children().length > 0) {
             console.log(new Date().getTime() + " Defer Loaded");
-            var guilds = $(".guilds li:first-child");
+            var guilds = $(".guilds>li:first-child");
 
             guilds.after($("<li></li>", { id: "bd-pub-li", css: { "height": "20px", "display": settingsCookie["bda-gs-1"] == true ? "" : "none" } }).append($("<div/>", { class: "guild-inner", css: { "height": "20px", "border-radius": "4px" } }).append($("<a/>").append($("<div/>", { css: { "line-height": "20px", "font-size": "12px" }, text: "public", id: "bd-pub-button" })))));
 


### PR DESCRIPTION
Problem was that the selector was looking for the first child that's a list item for all the children of .guilds, which also matched the .dms span