### PR TITLE
added linux support

### DIFF
--- a/NodeInstaller/index.js
+++ b/NodeInstaller/index.js
@@ -49,7 +49,7 @@ function install() {
             _discordPath = "/Applications/Discord.app/Contents/Resources"; // Defaults to Applications directory
         } else if (_os == "linux") {
 			_importSplice = 63;
-			_functionCallSplice = 510;
+			_functionCallSplice = 517;
 			_functionSplice = 593;
 			_discordPath = "/opt/DiscordCanary/resources";
 			// not sure where the .deb install, and most people are going to 

--- a/NodeInstaller/index.js
+++ b/NodeInstaller/index.js
@@ -46,8 +46,15 @@ function install() {
             _importSplice = 67;
             _functionCallSplice = 446;
             _functionSplice = 547;
-            _discordPath = "/Applications/Discord.app/Contents/Resources" // Defaults to Applications directory
-        }
+            _discordPath = "/Applications/Discord.app/Contents/Resources"; // Defaults to Applications directory
+        } else if (_os == "linux") {
+			_importSplice = 63;
+			_functionCallSplice = 510;
+			_functionSplice = 593;
+			_discordPath = "/opt/DiscordCanary/resources";
+			// not sure where the .deb install, and most people are going to 
+			// use the tar archive so I just picked a good default location
+		}
     }
     console.log("Looking for discord resources at: " + _discordPath);
 
@@ -99,7 +106,7 @@ function install() {
                     console.log("Injecting index.js");
 
                     var data = fs.readFileSync(_discordPath + _index).toString().split("\n");
-                    data.splice(_importSplice, 0, 'var _betterDiscord = require(\'betterdiscord\');\n');
+                    data.splice(_importSplice, 0, 'var _betterDiscord = require(\'BetterDiscord\');\n');
                     data.splice(_functionCallSplice, 0, splice);
 
                     fs.writeFile(_discordPath + _index, data.join("\n"), function(err) {

--- a/lib/BetterDiscord.js
+++ b/lib/BetterDiscord.js
@@ -9,7 +9,7 @@
 //Imports
 var _fs = require("fs");
 var _config = require("./config.json");
-var _utils = require("./utils");
+var _utils = require("./Utils");
 var _ipc = require('ipc');
 
 var _repo = "Jiiks";
@@ -56,7 +56,7 @@ function BetterDiscord(mainWindow) {
 
 BetterDiscord.prototype.initLoaders = function(){
     var os = process.platform;
-    var _dataPath = os == "win32" ? process.env.APPDATA : os == 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local';
+    var _dataPath = os == "win32" ? process.env.APPDATA : os == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + '/.config';
     _dataPath += "/BetterDiscord/";
 
     if (!_fs.existsSync(_dataPath)) {
@@ -136,7 +136,7 @@ BetterDiscord.prototype.createAndCheckData = function(callback) {
 
     //New data path
     //noinspection JSUnresolvedVariable
-    _dataPath = _os == "win32" ? process.env.APPDATA : _os == 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local';
+    _dataPath = _os == "win32" ? process.env.APPDATA : _os == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + '/.config';
     _dataPath += "/BetterDiscord";
     _userFile = _dataPath + "/user.json";
 


### PR DESCRIPTION
This adds support for the alpha linux client that can be found here: https://www.reddit.com/r/discordapp/comments/4bu7lm/discord_linux_very_experimental_canary_release/

sorry about that mess with the installer's index.js, I believe my editor or git replaced all crlf's with lf's

how to install:

``` bash
cd
mkdir discord
cd discord

# Install discord in /opt/
wget https://storage.googleapis.com/discord-developer/test/discord-canary-0.0.1.tar.gz
tar -xzvf discord-canary-0.0.1.tar.gz
sudo cp -r DiscordCanary /opt/
sudo ln -s /opt/DiscordCanary/DiscordCanary /usr/bin/discord

# Install BetterDiscord
git clone https://github.com/Jiiks/BetterDiscordApp.git
mv BetterDiscordApp BetterDiscord
cp BetterDiscord/NodeInstaller/* .
cp BetterDiscord/splice .
npm install asar wrench
sudo ./install.sh
```

NOTE: for those who would like to try this before it gets merged or if it doesn't get merged, just replace Jiiks with Francesco149 in the git clone command

Note that discord might open at very weird positions (in my case the top left corner of my 2nd monitor).

EDIT:
Since I dislike font smoothing, I also made a basic css to disable most font smoothing (assumes you already disabled all hinting in your OS):

``` css
body, .tab-bar-item { 
    -webkit-font-smoothing: none; 
    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
}
```

the webkit line is probably useless but I'll keep it just to be sure
not sure why the default font is smoothed even with hinting and smoothing disabled system-wide

NOTE:
Since 0.0.1 the discord window may be broken on start-up. If it is, close the window and terminate discord from the tray icon and re-start it. Keep doing this until it displays correctly. This is a Discord issue, not BetterDiscord's.
