### PR TITLE
Fixed emote modifier split

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -510,12 +510,15 @@ EmoteModule.prototype.injectEmote = function (node) {
             var emoteClass = "";
             var allowedClasses = ["emoteflip", "emotespin", "emotepulse", "emotespinflip", "emotespin2", "emotespin3"];
             if(word.indexOf(":") > -1) {
-                userEmoteCss = true;
-                sWord = word.split(":")[0];
-                if(settingsCookie["bda-es-8"]) {
-                    emoteClass = "emote" + word.split(":")[1];
-                    if(allowedClasses.indexOf(emoteClass) < 0) {
-                        emoteClass = "";
+                var split = word.split(/:(?!.*:)/);
+                if (split[0] != "" && split[1] != "") {
+                    userEmoteCss = true;
+                    sWord = split[0];
+                    if(settingsCookie["bda-es-8"]) {
+                        emoteClass = "emote" + split[1];
+                        if(allowedClasses.indexOf(emoteClass) < 0) {
+                            emoteClass = "";
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes emotes with ':' in their names (for plugins adding custom emotes).
However, it is still not possible to apply a modifier for emotes starting and ending with a ':' (":hap::spin"), for discord put ":hap:" and "spin" in a different html tag.