### PR TITLE
Fix installer error; erroneous folder creation

### DIFF
--- a/Installers/Node/index.js
+++ b/Installers/Node/index.js
@@ -18,7 +18,7 @@ var _discordPath;
 var _appFolder = "/app";
 var _appArchive = "/app.asar";
 var _packageJson = _appFolder + "/package.json";
-var _index = _appFolder + "/app/index.js";
+var _index = _appFolder + "/index.js";
 
 var _force = false;
 

--- a/Installers/Node/index.js
+++ b/Installers/Node/index.js
@@ -62,12 +62,6 @@ function install() {
                 console.log("Deleted " + _discordPath + _appFolder + " folder.");
             }
 
-            if(fs.existsSync(_discordPath + "/node_modules/BetterDiscord")) {
-                console.log("Deleting " + _discordPath + "/node_modules/BetterDiscord" + " folder.");
-                wrench.rmdirSyncRecursive(_discordPath + "/node_modules/BetterDiscord");
-                console.log("Deleted " + _discordPath + "/node_modules/BetterDiscord" + " folder.");
-            }
-
             console.log("Looking for app archive");
             if(fs.existsSync(_discordPath + _appArchive)) {
                 console.log("App archive found at: " + _discordPath + _appArchive);
@@ -79,9 +73,11 @@ function install() {
             console.log("Extracting app archive");
             asar.extractAll(_discordPath + _appArchive, _discordPath + _appFolder);
 
+            if(!fs.existsSync(_discordPath + _appFolder + "/node_modules")) {
+                // highly unlikely to reach here, but ensuring node modules folder exists
+                fs.mkdirSync(_discordPath + _appFolder + "/node_modules");
+            }
             console.log("Copying BetterDiscord");
-
-            fs.mkdirSync(_discordPath + "/node_modules/BetterDiscord");
 
             wrench.copyDirSyncRecursive(__dirname + "/BetterDiscord/", _discordPath + _appFolder  +  "/node_modules/BetterDiscord/", {forceDelete: true});
 


### PR DESCRIPTION
Removed lines check for and delete/make a folder in Resources rather than app. Nothing ends up going into this folder.

Due to lines above (checking for Resources/app), the first removed block is basically unreachable if it means to target Resources/app/node_modules/BetterDiscord

Reworked is: delete app/ , extract app/ , make a paranoid check to ensure app/node_modules/ , force copy BetterDiscord into app/node_modules

Should fix https://github.com/Jiiks/BetterDiscordApp/issues/341 in conjunction with https://github.com/Jiiks/BetterDiscordApp/pull/336
