### PR TITLE
Fix Node installer

### DIFF
--- a/Installers/Node/index.js
+++ b/Installers/Node/index.js
@@ -18,7 +18,7 @@ var _discordPath;
 var _appFolder = "/app";
 var _appArchive = "/app.asar";
 var _packageJson = _appFolder + "/package.json";
-var _index = _appFolder + "/app/index.js";
+var _index = _appFolder + "/index.js";
 
 var _force = false;
 


### PR DESCRIPTION
The path of the index.js was wrong (it was app/app/index.js), so I removed the redundant "app/".