### PR TITLE
Reduce cases in Node installer

### DIFF
--- a/Installers/Node/index.js
+++ b/Installers/Node/index.js
@@ -227,14 +227,10 @@ function init() {
 
             switch(alc) {
                 case "y":
-                    install();
-                    break;
                 case "yes":
                     install();
                     break;
                 case "n":
-                    process.exit();
-                    break;
                 case "no":
                     process.exit();
                     break;


### PR DESCRIPTION
Who needs 'em anyways?

The cases fall through.