### PR TITLE
fix case-sensitive name for linux installation

### DIFF
--- a/lib/BetterDiscord.js
+++ b/lib/BetterDiscord.js
@@ -10,7 +10,7 @@
 
 var _fs = require("fs");
 var _config = require("./config.json");
-var _utils = require("./utils");
+var _utils = require("./Utils");
 var _utils2;
 var _bdIpc = require('electron').ipcMain;
 var _error = false;


### PR DESCRIPTION
```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Cannot find module './utils'
    at Module._resolveFilename (module.js:455:15)
    at Function.Module._resolveFilename (/opt/discord-canary/resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.Module._load (module.js:403:25)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/opt/better-discord/BetterDiscordApp-stable16/lib/BetterDiscord.js:13:14)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
```