### PR TITLE
Fix path to the bdStorage.json for case-sensitive partitions

### DIFF
--- a/lib/BetterDiscord.js
+++ b/lib/BetterDiscord.js
@@ -34,9 +34,9 @@ bdPluginStorage.defaults = {
 };
 
 function initStorage() {
-    if(!_fs.existsSync(_cfg.dataPath + "/bdstorage.json")) {
+    if(!_fs.existsSync(_cfg.dataPath + "/bdStorage.json")) {
         bdStorage.data = bdStorage.defaults.data;
-        _fs.writeFileSync(_cfg.dataPath + "/bdstorage.json", JSON.stringify(bdStorage, null, 4));
+        _fs.writeFileSync(_cfg.dataPath + "/bdStorage.json", JSON.stringify(bdStorage, null, 4));
     } else {
         bdStorage.data = JSON.parse(_fs.readFileSync(_cfg.dataPath + "/bdStorage.json"));
     }
@@ -62,7 +62,7 @@ bdStorage.get = function(i, m, pn) {
 bdStorage.set = function(i, v, m, pn) {
     if(m) {
         bdStorage.data[i] = v;
-        _fs.writeFileSync(_cfg.dataPath + "/bdstorage.json", JSON.stringify(bdStorage.data, null, 4));
+        _fs.writeFileSync(_cfg.dataPath + "/bdStorage.json", JSON.stringify(bdStorage.data, null, 4));
     } else {
         if(bdPluginStorage[pn] === undefined) bdPluginStorage[pn] = {};
         bdPluginStorage[pn][i] = v;


### PR DESCRIPTION
BetterDiscord is searching for `bdStorage.json` but the file was created as `bdstorage.json`.