### PR TITLE
Update version of BD in config.json

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -1,6 +1,6 @@
 {
   "Core": {
-    "Version": "0.2.8"
+    "Version": "0.2.82"
   },
   "EmoteModule": {
     "Twitch":{
@@ -25,7 +25,7 @@
         "beta": false,
         "local": false,
         "localServer": "http://localhost",
-        "version": "0.2.8",
+        "version": "0.2.82",
         "updater": null,
         "hash": null,
         "dataPath": null,


### PR DESCRIPTION
We might still get that message warning us that BetterDiscord is not up-to-date, while we're actually using the latest version.