### PR TITLE
Fix Electron installer for OSX

### DIFF
--- a/Installers/Electron/src/utils.js
+++ b/Installers/Electron/src/utils.js
@@ -73,7 +73,7 @@ class Utils {
                 });
                 return path;
             },
-            "darwin": () => "/Applications/Discord.app",
+            "darwin": () => "/Applications/Discord.app/Contents",
             "linux": () => "" // TODO
         }[platform]();
 

--- a/Installers/Electron/src/utils.js
+++ b/Installers/Electron/src/utils.js
@@ -74,7 +74,7 @@ class Utils {
                 return path;
             },
             "darwin": () => "/Applications/Discord.app/Contents",
-            "linux": () => "/usr/share/discord-canary"
+            "linux": () => "/usr/share/discord"
         }[platform]();
 
     }

--- a/Installers/Electron/src/utils.js
+++ b/Installers/Electron/src/utils.js
@@ -74,7 +74,7 @@ class Utils {
                 return path;
             },
             "darwin": () => "/Applications/Discord.app/Contents",
-            "linux": () => "" // TODO
+            "linux": () => "/usr/share/discord-canary"
         }[platform]();
 
     }
@@ -88,7 +88,8 @@ class Utils {
                 return `${process.env.HOME}/.local/share/BetterDiscord`;
             },
             "linux": () => {
-                return ""; // TODO
+                // FIXME: for a non-root user, a path like OSX's makes more sense
+                return "/usr/local/share/BetterDiscord";
             }
         }[platform]();
     }

--- a/Installers/Electron/src/utils.js
+++ b/Installers/Electron/src/utils.js
@@ -84,6 +84,9 @@ class Utils {
             "win32": () => {
                 return `${process.env.APPDATA}/BetterDiscord/lib`;
             },
+            "darwin": () => {
+                return ""; // TODO
+            },
             "linux": () => {
                 return ""; // TODO
             }

--- a/Installers/Electron/src/utils.js
+++ b/Installers/Electron/src/utils.js
@@ -85,7 +85,7 @@ class Utils {
                 return `${process.env.APPDATA}/BetterDiscord/lib`;
             },
             "darwin": () => {
-                return ""; // TODO
+                return `${process.env.HOME}/.local/share/BetterDiscord`;
             },
             "linux": () => {
                 return ""; // TODO


### PR DESCRIPTION
As when running on Linux, choosing a specific directory for "install path" is required.

Leaving it blank will cause it to be treated as relative to the current directory.