### PR TITLE
[dp3] hide the active BD settings panel when the settings overlay is closed

### DIFF
--- a/client/src/ui/components/settingspanel.tsx
+++ b/client/src/ui/components/settingspanel.tsx
@@ -138,6 +138,14 @@ export class CSettingsPanel extends BdMultiComponent {
 
     constructor() {
         super();
+
+        Events.on('bd.settingsClosed', () => {
+            this.setState({
+                selectedId: 'none'
+            });
+            this.addContainerClass('bd-hidden', this.contentPanel);
+        });
+
         Events.on('global.click', e => {
             const target: any = e.target as any;
             if(

--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -25,7 +25,14 @@ export class UI {
 
     private eventListeners(): void {
         Events.on('mutation.childList', mutation => {
-            const { addedNodes, target } = mutation;
+            const { addedNodes, removedNodes, target } = mutation;
+
+            if (removedNodes.length > 0 && target) {
+                if (target.className.includes(settingsPanelClassSelector)) {
+                    Events.emit('bd.settingsClosed');
+                }
+            }
+
             if(!addedNodes || addedNodes.length <= 0 || !target) return;
 
             if(target.className.includes(settingsPanelClassSelector)) {


### PR DESCRIPTION
I added an Event `bd.settingsClosed` that is fired when a node is removed from the 'layers' div and an event listener for `bd.settingsClosed` in `CSettingsPanel`'s constructor to add the `bd-hidden` class to the current contentPanel and reset the selectedId to 'none'.

Not sure if 'settingsClosed' should be in `bd` scope or not.

Fixes the first point in #593 