### PR TITLE
undo the linux breakage in BetterDiscord.js

### DIFF
--- a/lib/BetterDiscord.js
+++ b/lib/BetterDiscord.js
@@ -10,7 +10,7 @@
 
 var _fs = require("fs");
 var _config = require("./config.json");
-var _utils = require("./utils");
+var _utils;
 var _utils2;
 var _bdIpc = require('electron').ipcMain;
 var _error = false;
@@ -34,9 +34,9 @@ bdPluginStorage.defaults = {
 };
 
 function initStorage() {
-    if(!_fs.existsSync(_cfg.dataPath + "/bdstorage.json")) {
+    if(!_fs.existsSync(_cfg.dataPath + "/bdStorage.json")) {
         bdStorage.data = bdStorage.defaults.data;
-        _fs.writeFileSync(_cfg.dataPath + "/bdstorage.json", JSON.stringify(bdStorage, null, 4));
+        _fs.writeFileSync(_cfg.dataPath + "/bdStorage.json", JSON.stringify(bdStorage, null, 4));
     } else {
         bdStorage.data = JSON.parse(_fs.readFileSync(_cfg.dataPath + "/bdStorage.json"));
     }
@@ -62,7 +62,7 @@ bdStorage.get = function(i, m, pn) {
 bdStorage.set = function(i, v, m, pn) {
     if(m) {
         bdStorage.data[i] = v;
-        _fs.writeFileSync(_cfg.dataPath + "/bdstorage.json", JSON.stringify(bdStorage.data, null, 4));
+        _fs.writeFileSync(_cfg.dataPath + "/bdStorage.json", JSON.stringify(bdStorage.data, null, 4));
     } else {
         if(bdPluginStorage[pn] === undefined) bdPluginStorage[pn] = {};
         bdPluginStorage[pn][i] = v;
@@ -79,6 +79,7 @@ function BetterDiscord(mainWindow) {
     _cfg = _config.cfg;
     _cfg.version = _config.Core.Version;
     _cfg.os = process.platform;
+    _utils = _cfg.os == "linux" ? require("./Utils") : require("./utils");
     _utils2 = new _utils.Utils(mainWindow);
     hook();
     createAndCheckData();
@@ -87,7 +88,7 @@ function BetterDiscord(mainWindow) {
 function createAndCheckData() {
     getUtils().log("Checking data/cache");
 
-    _cfg.dataPath = (_cfg.os == 'win32' ? process.env.APPDATA : _cfg.os == 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local') + '/BetterDiscord/';
+    _cfg.dataPath = (_cfg.os == 'win32' ? process.env.APPDATA : _cfg.os == 'darwin' ? process.env.HOME + '/Library/Preferences' : process.env.HOME + '/.config') + '/BetterDiscord/';
     _cfg.userFile = _cfg.dataPath + 'user.json';
 
     try {
@@ -227,7 +228,7 @@ function updateExtData() {
             'type': 'javascript',
             'resource': 'Main JS',
             'domain': _cfg.updater.CDN,
-            'url': '//' + _cfg.updater.CDN + '/' + _cfg.repo + '/BetterDiscordApp/' + _cfg.hash + '/js/main.min.js',
+            'url': '//' + _cfg.updater.CDN + '/' + _cfg.repo + '/BetterDiscordApp/' + _cfg.hash + '/js/main.js',
             'localurl': _cfg.localServer + '/BetterDiscordApp/js/main.js?v=1.1',
             'message': 'load-emoteData-twitchGlobal',
             'cacheable': false,


### PR DESCRIPTION
these changes were accidentally undone in commit 9ab77a8 , breaking some things in linux. though not too sure about the main.js -> main.min.js change, it was done in the same commit and didn't seem to have anything to do with the emotes so I assumed that was accidental as well.

it'd be nice to have my linux install script working again it kinda relies on these things being not fuckered in the bd source